### PR TITLE
fix: wrong icon match and fix nil error

### DIFF
--- a/step.rb
+++ b/step.rb
@@ -88,13 +88,13 @@ def filter_app_icon(infos, apk_path)
 
   # application-icon-65534:'res/mipmap-anydpi-v26/ic_launcher.xml'
   app_icon_match = infos.scan(/application-icon-[0-9]+:\'.*\/(.*).xml\'/)
-  return `#{aapt_path} l #{apk_path} | grep #{app_icon_match[0][0]}.png | tail -1`.strip if app_icon_match
+  return `#{aapt_path} l #{apk_path} | grep #{app_icon_match[0][0]}.png | tail -1`.strip if app_icon_match && app_icon_match[0]
 
   # application: label='CardsUp' icon='res/mipmap-hdpi-v4/ic_launcher.png'
   app_icon_regex = 'application: label=\'(?<label>.*)\' icon=\'(?<icon>.*)\''
   app_icon_match = infos.match(app_icon_regex)
 
-  return app_icon_match.captures[0]  if app_icon_match && app_icon_match.captures
+  return app_icon_match.captures[1]  if app_icon_match && app_icon_match.captures
 
   return ''
 end


### PR DESCRIPTION
Hi there, we found 2 issues into the filter_app_icon function. 

First, since gradle 4.2 we got this for our aapt dump --> 
<img width="366" alt="Capture d’écran 2021-05-06 à 14 32 40" src="https://user-images.githubusercontent.com/16080757/117298694-f33af280-ae77-11eb-89bf-90a7925eadfc.png">


We can notice that we don't have xxxhdpi... anymore. So we got an error on our build bitrise --> 

<img width="748" alt="Capture d’écran 2021-05-06 à 14 26 18" src="https://user-images.githubusercontent.com/16080757/117297900-07322480-ae77-11eb-9704-2920f8dd1409.png">

We found 2 issues : 

- When the code try to get app_icon_match for : # application-icon-65534:'res/mipmap-anydpi-v26/ic_launcher.xml', app_icon_match[0] is null and the error undefined method `[]' for nil:NilClass appeared. 
To correct that I just add this condition -> "&& app_icon_match[0]"

- The second is in the app_icon_regex we get 2 captures (label and icon) but we return the first one (return app_icon_match.captures[0] so the label and not the icon)
To correct that just get the second item (icon) with -> "return app_icon_match.captures[1]"


Co-Authored By @MickaCapi