### PR TITLE
Fix bundler setup

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -7,6 +7,7 @@ set -e
 export BUNDLE_GEMFILE="$THIS_SCRIPT_DIR/Gemfile"
 
 bundle update --bundler
-bundle install --without test --jobs 20 --retry 5
+bundle config set --local without "test"
+bundle install --jobs 20 --retry 5
 
 bundle exec ruby "$THIS_SCRIPT_DIR/step.rb" -a "${apk_path}"


### PR DESCRIPTION
**Issue:** 
use --without flag for the new bundler version - 4.0.0.beta1

**Log:** 
Fetching gem metadata from https://rubygems.org/.
Updating bundler to 4.0.0.beta1.
Fetching bundler 4.0.0.beta1
Installing bundler 4.0.0.beta1
Fetching gem metadata from https://rubygems.org/.
The Gemfile specifies no dependencies
Resolving dependencies...
Bundle updated!
The `--without` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set without 'test'`, and stop using this flag

**Documentation:** https://github.com/rubygems/bundler/blob/d4993be66fa2e76b3ca00ea56a51ecab5478b726/UPGRADING.md#bundler-3